### PR TITLE
Edits client-side requests from absolute path to using location.hostname

### DIFF
--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -29,7 +29,7 @@ class App extends React.Component {
   }
 
   getPhotoReviews() {
-    $.get(`http://localhost:3001/api/photo-reviews/${this.state.id}`)
+    $.get(`http://${location.hostname}:3001/api/photo-reviews/${this.state.id}`)
       .done((reviews) => {
         // formatting for photo carousel
         var slides = [[], [], [], [], []];

--- a/client/src/components/ReviewList.jsx
+++ b/client/src/components/ReviewList.jsx
@@ -37,7 +37,7 @@ class ReviewList extends React.Component {
   }
 
   getItemReviews(sort) {
-    $.get(`http://localhost:3001/api/item-reviews/${this.state.id}/${sort}`)
+    $.get(`http://${location.hostname}:3001/api/item-reviews/${this.state.id}/${sort}`)
       .done((reviews) => {
         this.setState({ itemReviews: reviews })
       })
@@ -47,7 +47,7 @@ class ReviewList extends React.Component {
   }
 
   getShopReviews(sort) {
-    $.get(`http://localhost:3001/api/store-reviews/${this.state.id}/${sort}`)
+    $.get(`http://${location.hostname}:3001/api/store-reviews/${this.state.id}/${sort}`)
       .done((reviews) => {
         this.setState({ shopReviews: reviews })
       })


### PR DESCRIPTION
Found this bug when deploying this server. When I had 'localhost' hard-coded as the path for client-side requests, it would fail when it needed to make a request to my instance's hostname.